### PR TITLE
[Bodge?] Adjusted setup.py to resolve installation problems

### DIFF
--- a/Development/Source/setup.py
+++ b/Development/Source/setup.py
@@ -6,5 +6,7 @@ setup(name='tapestry',
       author='Zac Adam-MacEwen',
       author_email='zadammac@kenshosec.com',
       url='https://www.github.com/zadammac/Tapestry',
-      packages=['tapestry', 'python-gnupg', 'paramiko'],
+      packages=['tapestry'],
+      install_requires=['pysftp', 'python-gnupg', 'paramiko'],
      )
+1


### PR DESCRIPTION
I was having some trouble getting pip install to work for me on Manjaro and macOS. I made a couple of tweaks to setup.py and it plays nice enough for me to push beyond that. I suspect this wasn't necessary for someone who knows what they're doing, but I figured I'd post it anyway.

Prior to these adjustments, I'd error out like so:

![Screen Shot 2020-03-19 at 5 29 48 PM](https://user-images.githubusercontent.com/27747481/77126689-439e8900-6a07-11ea-87eb-fe9534c196a3.png)

`Processing ./Development/Source
    ERROR: Command errored out with exit status 1:
     command: /Users/erica/Documents/Projects/Tapestry/venv/bin/python -c 'import sys, setuptools, tokenize; sys.argv[0] = '"'"'/private/var/folders/rf/k01lhfyj7r56ptjhkpvf8gmh0000gn/T/pip-req-build-t7ybvluc/setup.py'"'"'; __file__='"'"'/private/var/folders/rf/k01lhfyj7r56ptjhkpvf8gmh0000gn/T/pip-req-build-t7ybvluc/setup.py'"'"';f=getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' egg_info --egg-base /private/var/folders/rf/k01lhfyj7r56ptjhkpvf8gmh0000gn/T/pip-req-build-t7ybvluc/pip-egg-info
         cwd: /private/var/folders/rf/k01lhfyj7r56ptjhkpvf8gmh0000gn/T/pip-req-build-t7ybvluc/
    Complete output (9 lines):
    running egg_info
    creating /private/var/folders/rf/k01lhfyj7r56ptjhkpvf8gmh0000gn/T/pip-req-build-t7ybvluc/pip-egg-info/tapestry.egg-info
    writing /private/var/folders/rf/k01lhfyj7r56ptjhkpvf8gmh0000gn/T/pip-req-build-t7ybvluc/pip-egg-info/tapestry.egg-info/PKG-INFO
    writing dependency_links to /private/var/folders/rf/k01lhfyj7r56ptjhkpvf8gmh0000gn/T/pip-req-build-t7ybvluc/pip-egg-info/tapestry.egg-info/dependency_links.txt
    writing top-level names to /private/var/folders/rf/k01lhfyj7r56ptjhkpvf8gmh0000gn/T/pip-req-build-t7ybvluc/pip-egg-info/tapestry.egg-info/top_level.txt
    writing manifest file '/private/var/folders/rf/k01lhfyj7r56ptjhkpvf8gmh0000gn/T/pip-req-build-t7ybvluc/pip-egg-info/tapestry.egg-info/SOURCES.txt'
    /Users/erica/Documents/Projects/Tapestry/venv/lib/python3.7/site-packages/setuptools/dist.py:453: UserWarning: Normalizing '2.0.2.02' to '2.0.2.2'
      normalized_version,
    error: package directory 'python-gnupg' does not exist
    ----------------------------------------
ERROR: Command errored out with exit status 1: python setup.py egg_info Check the logs for full command output.`